### PR TITLE
Bugfix/hide no picture filter

### DIFF
--- a/pages/api/hashicorp.ts
+++ b/pages/api/hashicorp.ts
@@ -85,6 +85,7 @@ export default function handler(
 				P.ID AS PERSON_ID,
 				P.NAME AS PERSON_NAME,
 				P.AVATAR_URL,
+				P.TITLE,
 				D.ID AS DEPARTMENT_ID,
 				D.NAME AS DEPARTMENT_NAME
 			FROM PEOPLE P
@@ -148,6 +149,7 @@ export default function handler(
 				avatar: {
 					url: row.AVATAR_URL,
 				},
+				title: row.TITLE,
 				department: {
 					id: row.DEPARTMENT_ID,
 					name: row.DEPARTMENT_NAME,

--- a/pages/people/index.tsx
+++ b/pages/people/index.tsx
@@ -154,10 +154,12 @@ export default function PeoplePage({
 		const params: FetchFilteredDataOptions = { ...router.query, ...opts }
 
 		const urlParams = Object.entries(params)
-			.filter(
-				([key, value]) =>
-					(key === 'searchingName' || key === 'department') && value !== ''
-			)
+			.filter(([key, value]) => {
+				return (
+					((key === 'searchingName' || key === 'department') && value !== '') ||
+					key === 'hideNoPicture'
+				)
+			})
 			.map(([key, value]) => `${key}=${value}`)
 			.join('&')
 


### PR DESCRIPTION
This PR fixes a couple of issues related to filtering.

1. Filter API did not respect `hideNoPicture` param. This was due to an incorrect array filter when processing URL params for the fetch call.
2. Filter API did not bring back title, because I forgot to include it in the SELECT statement.
