### PR TITLE
filter department tree for root depts only

### DIFF
--- a/pages/people/index.tsx
+++ b/pages/people/index.tsx
@@ -116,7 +116,9 @@ export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
 	return {
 		props: {
 			allPeople: allPeople,
-			departmentTree: departmentRecordsToDepartmentTree(allDepartments),
+			departmentTree: departmentRecordsToDepartmentTree(allDepartments).filter(
+				(department) => department.parent == null
+			),
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes an issue where child departments were displaying at the root level in the department tree.
